### PR TITLE
cards are now clickable + hover effect

### DIFF
--- a/app/assets/stylesheets/components/_card_experience.scss
+++ b/app/assets/stylesheets/components/_card_experience.scss
@@ -1,13 +1,19 @@
 
 
 .card-experience {
-  width: 300px;
+  position: relative;
+  width: 360px;
   height: 400px;
   justify-content: center;
   align-items: center;
   text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
   border-radius: $card-border-radius;
   box-shadow: 0 0 15px rgba(0,0,0,0.2);
+
+  &:hover {
+    border: solid 1px lightgrey;
+    box-shadow: 0 0 15px 5px rgba(0,0,0,0.1);
+  }
 
   .card-experience-photo {
     width: 100%;
@@ -17,6 +23,15 @@
     border-top-right-radius: $card-border-radius;
     border-top-left-radius: $card-border-radius;
   }
+}
+
+.card-link {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+
 }
 
 .card-experience-description {

--- a/app/views/experiences/_experience.html.erb
+++ b/app/views/experiences/_experience.html.erb
@@ -1,10 +1,11 @@
-<div class="card-experience">
+<div class="card-experience" >
   <% if experience.photo&.attached? %>
     <div class="card-experience-photo" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path experience.photo.key, crop: :fill %>')"></div>
   <% end %>
   <div class="card-experience-description">
-   <p><i class="fa-solid fa-star"></i> <%= [4.95, 4.52, 4.8, 4.6, 4.9].sample %></p>
-    <h4><%= link_to experience.title, experience_path(experience.id)%></h4>
+  <p><i class="fa-solid fa-star"></i> <%= [4.95, 4.52, 4.8, 4.6, 4.9].sample %></p>
+    <h4><%=experience.title%></h4>
     <p><%= experience.description%></p>
   </div>
+  <%= link_to '', experience_path(experience.id), class: 'card-link'%>
 </div>

--- a/app/views/experiences/index.html.erb
+++ b/app/views/experiences/index.html.erb
@@ -7,8 +7,10 @@
   </div>
   <div >
     <%= render "marketing" %>
-    <h2 class="container cards-experiences-title">Popular experiences <%= link_to "Add an experience", new_experience_path%></h2>
-
+    <div>
+        <h2 class="container cards-experiences-title">Popular experiences </h2>
+        <%= link_to "Add an experience", new_experience_path%>
+    </div>
   </div>
   <hr class="cards-experience-line" />
 


### PR DESCRIPTION
guys 
worked on the cards in the home page
- cards are now wider (360px vs 300px) and clickable
- added a hover effect

Ian will push a new app/assets/stylesheets/components/_container.scss to change  from  width: 85%;

please review and merge